### PR TITLE
issue 9: fix shell evaluation giving CR when using under Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Though the it is supposed to work on all OSs / Sublime 2/3, this feature is test
 
 Please kindly report to us if you find an issue. We'd be happy to fix it.
 
+Caveat: If you are using windows, your snippet will be evaluated by `cmd.exe`(awesome!). Windows shell eval is supported as-is. Good luck.
+
 #### Demo
 ![](shell-eval.gif)
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -80,6 +80,7 @@ class EvaluateCall(threading.Thread):
             try:
                 p = subprocess.Popen(shell_code,
                                     shell=True,
+                                    universal_newlines=True,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
                 # stderr goes to stdout
@@ -88,7 +89,7 @@ class EvaluateCall(threading.Thread):
                 if type(out) == bytes:
                     out = out.decode()
 
-                # Remove the last newline
+                # Remove the LAST newline
                 if out.endswith('\n'):
                     out = out[:-1]
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -5,6 +5,7 @@ import threading
 import math
 import datetime
 import subprocess
+import platform
 
 sublime_version = 2
 
@@ -80,7 +81,6 @@ class EvaluateCall(threading.Thread):
             try:
                 p = subprocess.Popen(shell_code,
                                     shell=True,
-                                    universal_newlines=True,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.STDOUT)
                 # stderr goes to stdout
@@ -89,7 +89,12 @@ class EvaluateCall(threading.Thread):
                 if type(out) == bytes:
                     out = out.decode()
 
-                # Remove the LAST newline
+                # translate \r\n to \n on Windows
+                # (I suppose if you are using a real OS, you want to keep output as-is)
+                if platform.system() == 'Windows':
+                    out = out.replace('\r\n', '\n')
+
+                # Trim the LAST newline
                 if out.endswith('\n'):
                     out = out[:-1]
 


### PR DESCRIPTION
Enable `universal_newlines` mode so that eval on windows don't throw half EOL (#9)